### PR TITLE
Use the new ContextMixin from Django 1.5

### DIFF
--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -3,6 +3,7 @@ from django.views.generic.detail import SingleObjectTemplateResponseMixin
 from extra_views.formsets import BaseInlineFormSetMixin
 from django.http import HttpResponseRedirect
 from django.forms.formsets import all_valid
+from .compat import ContextMixin
 
 
 class InlineFormSet(BaseInlineFormSetMixin):
@@ -93,15 +94,15 @@ class UpdateWithInlinesView(SingleObjectTemplateResponseMixin, BaseUpdateWithInl
     template_name_suffix = '_form'
 
 
-class NamedFormsetsMixin(object):
+class NamedFormsetsMixin(ContextMixin):
     inlines_names = []
 
     def get_context_data(self, **kwargs):
-        ctx = super(NamedFormsetsMixin, self).get_context_data(**kwargs)
-        if not self.inlines_names:
-            return ctx
-        # We have formset or inlines in context, but never both
-        ctx.update(zip(self.inlines_names, kwargs.get('inlines',[])))
-        if 'formset' in kwargs:
-            ctx[self.inlines_names[0]] = kwargs['formset']
-        return ctx
+        context = {}
+        if self.inlines_names:
+            # We have formset or inlines in context, but never both
+            context.update(zip(self.inlines_names, kwargs.get('inlines', [])))
+            if 'formset' in kwargs:
+                context[self.inlines_names[0]] = kwargs['formset']
+        context.update(kwargs)
+        return super(NamedFormsetsMixin, self).get_context_data(**context)

--- a/extra_views/compat.py
+++ b/extra_views/compat.py
@@ -1,0 +1,15 @@
+# ContextMixin was introduced in Django 1.5, we provide a copy for earlier
+# versions.
+try:
+    from django.views.generic.base import ContextMixin
+except ImportError:
+    class ContextMixin(object):
+        """
+        A default context mixin that passes the keyword arguments received by
+        get_context_data as the template context.
+        """
+
+        def get_context_data(self, **kwargs):
+            if 'view' not in kwargs:
+                kwargs['view'] = self
+            return kwargs

--- a/extra_views/contrib/mixins.py
+++ b/extra_views/contrib/mixins.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 import datetime
 import operator
+from ..compat import ContextMixin
 
 VALID_STRING_LOOKUPS = ('iexact', 'contains', 'icontains', 'startswith', 'istartswith', 'endswith', 'iendswith',
     'search', 'regex', 'iregex')
@@ -123,7 +124,7 @@ class SortHelper(object):
         return sort
 
 
-class SortableListMixin(object):
+class SortableListMixin(ContextMixin):
     """
     You can provide either sort_fields as a plain list like ['id', 'some', 'foo__bar', ...]
     or, if you want to hide original field names you can provide list of tuples with aliace that will be used:
@@ -158,7 +159,8 @@ class SortableListMixin(object):
         return self._sort_queryset(qs)
 
     def get_context_data(self, **kwargs):
-        ctx = super(SortableListMixin, self).get_context_data(**kwargs)
+        context = {}
         if hasattr(self, 'sort_helper'):
-            ctx['sort_helper'] = self.sort_helper
-        return ctx
+            context['sort_helper'] = self.sort_helper
+        context.update(kwargs)
+        return super(SortableListMixin, self).get_context_data(**context)

--- a/extra_views/multi.py
+++ b/extra_views/multi.py
@@ -5,6 +5,7 @@ from django.forms.formsets import formset_factory
 from django.forms.models import modelformset_factory
 from django.forms import models as model_forms
 from django.forms import ValidationError
+from .compat import ContextMixin
 
 
 class FormProvider(object):
@@ -40,7 +41,7 @@ class FormProvider(object):
         return form
 
 
-class MultiFormMixin(object):
+class MultiFormMixin(ContextMixin):
     """
     Handle multiple forms in a single view
     """
@@ -99,9 +100,6 @@ class MultiFormMixin(object):
                 'data': self.request.POST,
                 'files': self.request.FILES,
             })
-        return kwargs
-
-    def get_context_data(self, **kwargs):
         return kwargs
 
     def get_success_url(self):


### PR DESCRIPTION
Django 1.5 introduces the ContextMixin to solve problems with multiple mixins defining get_context_data. It also sets the 'view' variable that points to the View which is quite handy. For more information, see the documentation: https://docs.djangoproject.com/en/dev/ref/class-based-views/mixins-simple/#contextmixin and the ticket that introduced it: https://code.djangoproject.com/ticket/16074

This patch adds support for using ContextMixin. I also modified the get_context_data methods to be all in the same style as the mixins in Django 1.5, so that it is clear what is going on and overriding variables will always work in the same way.

For earlier Django versions I added our own version of ContextMixin. I tested with both 1.4 and 1.5 and all tests pass with both versions.
