### PR TITLE
Remove del kwargs['initial']

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -244,7 +244,6 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         kwargs = super(BaseInlineFormSetMixin, self).get_formset_kwargs()
         kwargs['save_as_new'] = self.save_as_new
         kwargs['instance'] = self.object
-        del kwargs['initial']
         return kwargs
 
     def get_factory_kwargs(self):


### PR DESCRIPTION
Deletion of the 'initial' data key is preventing the inlineformsets to load with initial data. This is simple fix by removing that line.
