### PR TITLE
No .distinct unless there's a query

### DIFF
--- a/extra_views/contrib/mixins.py
+++ b/extra_views/contrib/mixins.py
@@ -89,7 +89,7 @@ class SearchableListMixin(object):
                         filters.extend([Q(**{field_name: dt}) for field_name in self.search_date_fields])
                 w_qs.append(reduce(operator.or_, filters))
             qs = qs.filter(reduce(operator.and_, w_qs))
-            qs.distinct()
+            qs = qs.distinct()
         return qs
 
 


### PR DESCRIPTION
Even if nothing is done, SearchableListMixin adds a .distinct() to the QS. In my use case, that incurred a 58% slowdown when viewing the index page without a ?q

Is the distinct really necessary? If it is, perhaps we could move it up a level so it's only applied if there's something to do?
