### PR TITLE
fixed documentation on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Django's class-based generic views are great, they let you accomplish a large nu
         :target: https://travis-ci.org/AndrewIngram/django-extra-views
 
 .. image:: https://pypip.in/d/django-extra-views/badge.png
-        :target: https://crate.io/packages/django-extra-views/
+        :target: https://pypi.python.org/pypi/django-extra-views/
 
 Installation
 ------------


### PR DESCRIPTION
URL off documentation was already in the file, but was not being rendered correctly.

Remove crate.io references on README.rst and change to pypi.python.org.

crate.io domain was sold to bigdata company

http://www.reddit.com/r/Python/comments/1wcp93/what_happened_to_crateio/

crateio/crate.io#18

I think at the moment there is no substitute for crate.io.
Are developing a new pypi, which can be seen in [1]

[1] https://github.com/pypa/warehouse
