### PR TITLE
Fixed bug when search_split is set to False

### DIFF
--- a/extra_views/contrib/mixins.py
+++ b/extra_views/contrib/mixins.py
@@ -20,8 +20,8 @@ VALID_STRING_LOOKUPS = (
 
 class SearchableListMixin(object):
     """
-    Filter queryset like a django admin search_fields does, but with little more intellegence:
-    if self.search_split is set to True (by default) it will split query to words (by whatespace)
+    Filter queryset like a django admin search_fields does, but with little more intelligence:
+    if self.search_split is set to True (by default) it will split query to words (by whitespace)
     Also tries to convert each word to date with self.search_date_formats and then search each word in separate field
     e.g. with query 'foo bar' you can find object with obj.field1__icontains='foo' and obj.field2__icontains=='bar'
 
@@ -43,7 +43,7 @@ class SearchableListMixin(object):
     def get_words(self, query):
         if self.search_split:
             return query.split()
-        return query
+        return [query]
 
     def get_search_fields_with_filters(self):
         fields = []


### PR DESCRIPTION
query is a string, so if it's not converted into an array, the for loop
in get_queryset() will iterate through individual characters. get_words
now returns an array containing one element (a "word" containing the
entire query) rather than just returning the string.
