### PR TITLE
Add Python 3 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Intended Audience :: Developers',
-        'Programming Language :: Python']
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3']
 )


### PR DESCRIPTION
This adds the Python3 trove classifier so that PyPI and tools such as caniusepython3 know that Python 3 is supported.
