### PR TITLE
Use open-ended dependency on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     url='https://github.com/AndrewIngram/django-extra-views',
     install_requires=[
         'Django >=1.3',
-        'six==1.5.2',
+        'six>=1.5.2',
     ],
     description="Extra class-based views for Django",
     long_description=open('README.rst', 'r').read(),
@@ -23,5 +23,6 @@ setup(
         'Framework :: Django',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3']
 )


### PR DESCRIPTION
Having six pinned to 1.5.2 causes issues for e.g. Oscar when other dependencies specify a more current version. AFAIK, six is outstanding at being backwards-compatible, so it should be safe to allow any version above 1.5.2 to be installed. 

AFAIK, django-extra-views is compatible with Python 2, so the classifiers should include it.
