### PR TITLE
extra_views.formsets: Add 'widgets' support to BaseFormSetMixin

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -22,6 +22,7 @@ class BaseFormSetMixin(object):
     max_num = None
     can_order = False
     can_delete = False
+    widgets = None
 
     def construct_formset(self):
         """
@@ -96,6 +97,7 @@ class BaseFormSetMixin(object):
             'max_num': self.max_num,
             'can_order': self.can_order,
             'can_delete': self.can_delete,
+            'widgets': self.widgets,
         }
 
         if self.get_formset_class():


### PR DESCRIPTION
Add the [new-in-Django-1.6 `widgets` field](https://docs.djangoproject.com/en/1.7/ref/forms/models/#django.forms.models.modelformset_factory).  Use like:

```
class ItemInline(InlineFormSet):
    model = Item
    widgets = {
        'your_date_field': forms.DateInput(attrs={'class': 'datepicker'}),
    }
```

Partially addresses #83.
