### PR TITLE
Fix all RemovedInDjango19Warning messages. Fixes #101

### DIFF
--- a/extra_views/generic.py
+++ b/extra_views/generic.py
@@ -1,4 +1,10 @@
-from django.contrib.contenttypes.generic import generic_inlineformset_factory, BaseGenericInlineFormSet
+import django
+
+if django.VERSION < (1, 8):
+    from django.contrib.contenttypes.generic import generic_inlineformset_factory, BaseGenericInlineFormSet
+else:
+    from django.contrib.contenttypes.forms import generic_inlineformset_factory, BaseGenericInlineFormSet
+
 from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, BaseInlineFormSetView, InlineFormSetView
 
 

--- a/extra_views/tests/models.py
+++ b/extra_views/tests/models.py
@@ -3,9 +3,14 @@ try:
     from django.utils.timezone import now
 except ImportError:
     now = datetime.datetime.now
+import django
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+
+if django.VERSION < (1, 8):
+    from django.contrib.contenttypes.generic import GenericForeignKey
+else:
+    from django.contrib.contenttypes.fields import GenericForeignKey
 
 STATUS_CHOICES = (
     (0, 'Placed'),
@@ -38,7 +43,7 @@ class Tag(models.Model):
     name = models.CharField(max_length=255)
     content_type = models.ForeignKey(ContentType, null=True)
     object_id = models.PositiveIntegerField(null=True)
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
 
     def __unicode__(self):
         return self.name

--- a/extra_views/tests/tests.py
+++ b/extra_views/tests/tests.py
@@ -7,7 +7,11 @@ import django
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
 from django.test import TransactionTestCase
-from django.utils.unittest import expectedFailure
+
+if django.VERSION < (1, 8):
+    from django.utils.unittest import expectedFailure
+else:
+    from unittest import expectedFailure
 
 from .models import Item, Order, Tag, Event
 


### PR DESCRIPTION
Hello @AndrewIngram,

I just made some changes to make `django-extra-views` compatible with Django 1.9. Most of them were in test modules, but it was still required so I took some time to fix everything. :)

Please note that all my changes work the same way, they check the current version of Django. Also, the new modules are used even with Django 1.8, since those modules already exist in this version (and it removes the warnings as well).

Feel free to comment or ask for any modification.

PS: I checked that the test suite still work with:
- Python 2.7 and Django 1.4.0
- Python 3.4 and Django 1.4.0
- Python 3.4 and Django 1.8.2

(and I let Travis to check the rest)