### PR TITLE
fields should'nt be __all__ if form_class is set

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -180,7 +180,7 @@ class ModelFormSetMixin(FormSetMixin, MultipleObjectMixin):
         Returns the keyword arguments for calling the formset factory
         """
         kwargs = super(ModelFormSetMixin, self).get_factory_kwargs()
-        if django.VERSION >= (1, 6) and self.fields is None:
+        if django.VERSION >= (1, 6) and self.fields is None and self.form_class is None:
             self.fields = '__all__'  # backward compatible with older versions
 
         kwargs.update({
@@ -257,7 +257,7 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         Returns the keyword arguments for calling the formset factory
         """
         kwargs = super(BaseInlineFormSetMixin, self).get_factory_kwargs()
-        if django.VERSION >= (1, 6) and self.fields is None:
+        if django.VERSION >= (1, 6) and self.fields is None and self.form_class is None:
             self.fields = '__all__'  # backward compatible with older versions
 
         kwargs.update({


### PR DESCRIPTION
This will result in problems with Django version 1.6 and newer as all form fields are added to the form