### PR TITLE
Add tests over django-master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 sudo: false
 language: python
+
 python:
   - "2.7"
   - "3.4"
   - "3.5"
+
 env:
   - DJANGO=django16
   - DJANGO=django17
   - DJANGO=django18
   - DJANGO=django19
+  - DJANGO=djangomaster
+
 matrix:
   exclude:
     - python: "3.4"
@@ -19,12 +23,17 @@ matrix:
       env: DJANGO=django16
     - python: "3.5"
       env: DJANGO=django17
+  allow_failures:
+    - env: DJANGO=djangomaster
 
 before_install:
   - pip install codecov
+
 install:
   - pip install tox
+
 script:
   - TOX_TEST_PASSENV="TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH" tox -e py${TRAVIS_PYTHON_VERSION//[.]/}-$DJANGO
+
 after_success:
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py{26,27}-django{16,17,18,19}
           py{34,35}-django{18,19}
+          py{27,34,35}-djangomaster
           docs
 
 [testenv]
@@ -16,6 +17,7 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9rc1,<1.10
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:docs]
 whitelist_externals=make


### PR DESCRIPTION
Hello,

I am suggest add tests over django master to fast feedback what can be broken in future django releases. It is failurable tests, so provide feedback, but isn't misleading for developer which create a pull requests. It doesn't affect GitHub pull requests status.

Greetings,
