### PR TITLE
Fixes #122: don't pass *args to get_context_data

### DIFF
--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -83,7 +83,7 @@ class ProcessFormWithInlinesView(FormView):
         form_class = self.get_form_class()
         form = self.get_form(form_class)
         inlines = self.construct_inlines()
-        return self.render_to_response(self.get_context_data(form=form, inlines=inlines, *args, **kwargs))
+        return self.render_to_response(self.get_context_data(form=form, inlines=inlines, **kwargs))
 
     def post(self, request, *args, **kwargs):
         """

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -390,6 +390,13 @@ class ModelWithInlinesTests(TestCase):
         order = Order.objects.get(id=order.id)
         self.assertTrue(order.action_on_save)
 
+    def test_url_arg(self):
+        """
+        Regression test for #122: get_context_data should not be called with *args
+        """
+        res = self.client.get('/inlines/123/new/')
+        self.assertEqual(res.status_code, 200)
+
 
 class CalendarViewTests(TestCase):
     def test_create(self):

--- a/extra_views_tests/urls.py
+++ b/extra_views_tests/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     url(r'^modelformset/custom/$', FormAndFormSetOverrideView.as_view()),
     url(r'^modelformset/paged/$', PagedModelFormSetView.as_view()),
     url(r'^inlineformset/(?P<pk>\d+)/$', OrderItemFormSetView.as_view()),
+    url(r'^inlines/(\d+)/new/$', OrderCreateView.as_view()),
     url(r'^inlines/new/$', OrderCreateView.as_view()),
     url(r'^inlines/new/named/$', OrderCreateNamedView.as_view()),
     url(r'^inlines/(?P<pk>\d+)/$', OrderUpdateView.as_view()),


### PR DESCRIPTION
The parent mixins/classes don't take `*args`, so we extra-views shouldn't pass them either.

Added a test that fails before the patch.