### PR TITLE
Remove Django 1.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.5"
 
 env:
-  - DJANGO=django16
   - DJANGO=django17
   - DJANGO=django18
   - DJANGO=django19
@@ -16,11 +15,7 @@ env:
 matrix:
   exclude:
     - python: "3.4"
-      env: DJANGO=django16
-    - python: "3.4"
       env: DJANGO=django17
-    - python: "3.5"
-      env: DJANGO=django16
     - python: "3.5"
       env: DJANGO=django17
   allow_failures:


### PR DESCRIPTION
The 1.6 build is failing without reason.
Django 1.6 is not supported since April 1st, 2015