### PR TITLE
[Django1.11] AttributeError: This QueryDict instance is immutable

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -92,7 +92,7 @@ class BaseFormSetMixin(object):
 
         if self.request.method in ('POST', 'PUT'):
             kwargs.update({
-                'data': self.request.POST,
+                'data': self.request.POST.copy(),
                 'files': self.request.FILES,
             })
         return kwargs


### PR DESCRIPTION
Quote from the 1.11 release notes[1]

```
For consistency with non-multipart requests,
MultiPartParser.parse() now leaves request.POST immutable.
If you’re modifying that QueryDict, you must now first copy it, e.g. request.POST.copy().
```

This is relevant in https://github.com/AndrewIngram/django-extra-views/blob/master/extra_views/formsets.py#L76. I tried running the automated tests with django1.11, but they passed. Changing `request.POST` to `request.POST.copy()` fixes my test failure.

[1] https://docs.djangoproject.com/en/2.0/releases/1.11/