### PR TITLE
Formset kwargs (New)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
   - "3.6"
 
 env:
-  - DJANGO=django17
-  - DJANGO=django18
   - DJANGO=django19
   - DJANGO=django110
   - DJANGO=django111
@@ -19,12 +17,6 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO=djangomaster
-    - python: "3.4"
-      env: DJANGO=django17
-    - python: "3.5"
-      env: DJANGO=django17
-    - python: "3.6"
-      env: DJANGO=django17
   allow_failures:
     - env: DJANGO=djangomaster
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Change History
 ==============
 
+0.xx.0
+------
+
+Backwards-incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Removed support for factory kwargs ``extra``, ``max_num``, ``can_order``,
+  ``can_delete``, ``ct_field``, ``formfield_callback``, ``fk_name``,
+  ``widgets``, ``ct_fk_field`` being set on ``BaseFormSetMixin`` and its
+  subclasses. Use ``BaseFormSetMixin.factory_kwargs`` instead.
+- Removed support for formset_kwarg ``save_as_new`` being set on
+  ``BaseInlineFormSetMixin`` and its subclasses. Use
+  ``BaseInlineFormSetMixin.formset_kwargs`` instead.
+
 0.10.0 (2018-02-28)
 ------------------
 Supported Versions:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Backwards-incompatible changes
 - Removed support for formset_kwarg ``save_as_new`` being set on
   ``BaseInlineFormSetMixin`` and its subclasses. Use
   ``BaseInlineFormSetMixin.formset_kwargs`` instead.
+- Removed support for ``get_extra_form_kwargs``. This can be set in the
+  dictionary key ``form_kwargs`` in ``BaseFormSetMixin.formset_kwargs`` instead.
 
 0.10.0 (2018-02-28)
 ------------------

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -36,18 +36,17 @@ This view will render the template :code:`myformset.html` with a context variabl
 validated, :code:`formset_valid` will be called which is where your handling logic
 goes, then it redirects to :code:`success_url`.
 
-FormSetView exposes all the parameters you'd normally be able to pass to
-formset_factory. Example (using the default settings)::
+FormSetView exposes all the parameters you'd normally be able to pass to the
+:code:`FormSet` constructor and formset_factory. Example (using the default
+settings)::
 
     class MyFormSetView(FormSetView):
         template_name = 'myformset.html'
         form_class = MyForm
         success_url = 'success/'
-        extra = 2
-        max_num = None
-        can_order = False
-        can_delete = False
-
+        factory_kwargs = {'extra': 2, 'max_num': None,
+                          'can_order': False, 'can_delete': False}
+        formset_kwargs = {'auto_id': 'my_id_%s'}
         ...
 
 
@@ -79,6 +78,16 @@ the class, which could filter on a URL kwarg (:code:`self.kwargs`), for example:
             slug = self.kwargs['slug']
             return super(MyModelFormSetView, self).get_queryset().filter(slug=slug)
 
+Optionally, :code:`fields` can be used to define the fields displayed in the
+formset::
+
+    class MyModelFormSetView(ModelFormSetView):
+        template_name = 'mymodelformset.html'
+        model = MyModel
+        fields = ['name', 'date', 'slug']
+
+:code:`exclude` can be set in an analogous way.
+
 
 InlineFormSetView
 -----------------
@@ -96,16 +105,18 @@ reviews related to a product::
 
         ...
 
-Aside from the use of `model` and `inline_model`, InlineFormSetView works
-more-or-less in the same way as ModelFormSetView.
+Aside from the use of :code:`model` and :code:`inline_model`,
+:code:`InlineFormSetView` works more-or-less in the same way as
+:code:`ModelFormSetView`.
 
 
 GenericInlineFormSetView
 ------------------------
 
 You can also use generic relationships for your inline formsets, this makes use
-of Django's :code:`generic_inlineformset_factory`. The usage is the same, but with the
-addition of :code:`ct_field` and :code:`ct_fk_field`::
+of Django's :code:`generic_inlineformset_factory`. :code:`ct_field` and
+:code:`fk_field` should be set in :code:`factory_kwargs` if they need to be
+changed from their default values::
 
     from extra_views.generic import GenericInlineFormSetView
 
@@ -113,9 +124,9 @@ addition of :code:`ct_field` and :code:`ct_fk_field`::
     class EditProductReviewsView(GenericInlineFormSetView):
         model = Product
         inline_model = Review
-        ct_field = "content_type"
-        ct_fk_field = "object_id"
-        max_num = 1
+        factory_kwargs = {'ct_field': 'content_type', 'fk_field': 'object_id',
+                          'max_num': 1}
+        formset_kwargs = {'save_as_new': True}
 
         ...
 

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -32,8 +32,14 @@ class BaseFormSetMixin(object):
         formset_class = self.get_formset()
         extra_form_kwargs = self.get_extra_form_kwargs()
 
-        # Hack to let as pass additional kwargs to each forms constructor. Be aware that this
-        # doesn't let us provide *different* arguments for each form
+        # Hack to let as pass additional kwargs to each forms constructor.
+        # Be aware that this doesn't let us provide *different* arguments for
+        # each form
+
+        # From Django 1.9 onwards this is not necessary as FormSet.__init__()
+        # accepts `form_kwargs` as the kwargs to pass to the constructor of each
+        # form. Once we have dropped support for Django 1.8, this step and the
+        # get_extra_form_kwargs method should be removed.
         if extra_form_kwargs:
             formset_class.form = wraps(formset_class.form)(partial(formset_class.form, **extra_form_kwargs))
 

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -1,5 +1,3 @@
-import warnings
-
 import django
 from django.views.generic.base import TemplateResponseMixin, View, ContextMixin
 from django.http import HttpResponseRedirect
@@ -30,11 +28,10 @@ class BaseFormSetMixin(object):
         formset_class = self.get_formset()
         if hasattr(self, 'get_extra_form_kwargs'):
             klass = type(self).__name__
-            warnings.warn(
+            raise DeprecationWarning(
                 'Calling {0}.get_extra_form_kwargs is no longer supported. '
                 'Set `form_kwargs` in {0}.formset_kwargs or override '
                 '{0}.get_formset_kwargs() directly.'.format(klass),
-                DeprecationWarning
             )
         return formset_class(**self.get_formset_kwargs())
 
@@ -94,11 +91,9 @@ class BaseFormSetMixin(object):
                      'formfield_callback', 'fk_name', 'widgets', 'ct_fk_field']:
             if hasattr(self, attr):
                 klass = type(self).__name__
-                warnings.warn(
+                raise DeprecationWarning(
                     'Setting `{0}.{1}` at the class level is now deprecated. '
-                    'Set `{0}.factory_kwargs` instead.'.format(klass, attr),
-                    DeprecationWarning
-
+                    'Set `{0}.factory_kwargs` instead.'.format(klass, attr)
                 )
 
         kwargs = self.factory_kwargs.copy()
@@ -238,11 +233,9 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         # Perform deprecation check
         if hasattr(self, 'save_as_new'):
             klass = type(self).__name__
-            warnings.warn(
+            raise DeprecationWarning(
                 'Setting `{0}.save_as_new` at the class level is now '
-                'deprecated. Set `{0}.formset_kwargs` instead.'.format(klass),
-                DeprecationWarning
-
+                'deprecated. Set `{0}.formset_kwargs` instead.'.format(klass)
             )
         kwargs = super(BaseInlineFormSetMixin, self).get_formset_kwargs()
         kwargs['instance'] = self.object

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -1,6 +1,4 @@
 import warnings
-from functools import partial
-from functools import wraps
 
 import django
 from django.views.generic.base import TemplateResponseMixin, View, ContextMixin
@@ -30,19 +28,14 @@ class BaseFormSetMixin(object):
         Returns an instance of the formset
         """
         formset_class = self.get_formset()
-        extra_form_kwargs = self.get_extra_form_kwargs()
-
-        # Hack to let as pass additional kwargs to each forms constructor.
-        # Be aware that this doesn't let us provide *different* arguments for
-        # each form
-
-        # From Django 1.9 onwards this is not necessary as FormSet.__init__()
-        # accepts `form_kwargs` as the kwargs to pass to the constructor of each
-        # form. Once we have dropped support for Django 1.8, this step and the
-        # get_extra_form_kwargs method should be removed.
-        if extra_form_kwargs:
-            formset_class.form = wraps(formset_class.form)(partial(formset_class.form, **extra_form_kwargs))
-
+        if hasattr(self, 'get_extra_form_kwargs'):
+            klass = type(self).__name__
+            warnings.warn(
+                'Calling {0}.get_extra_form_kwargs is no longer supported. '
+                'Set `form_kwargs` in {0}.formset_kwargs or override '
+                '{0}.get_formset_kwargs() directly.'.format(klass),
+                DeprecationWarning
+            )
         return formset_class(**self.get_formset_kwargs())
 
     def get_initial(self):
@@ -62,12 +55,6 @@ class BaseFormSetMixin(object):
         Returns the formset class to use in the formset factory
         """
         return self.formset_class
-
-    def get_extra_form_kwargs(self):
-        """
-        Returns extra keyword arguments to pass to each form in the formset
-        """
-        return {}
 
     def get_form_class(self):
         """

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -42,9 +42,9 @@ class BaseFormSetMixin(object):
 
     def get_initial(self):
         """
-        Returns the initial data to use for formsets on this view.
+        Returns a copy of the initial data to use for formsets on this view.
         """
-        return self.initial
+        return self.initial[:]
 
     def get_prefix(self):
         return self.prefix

--- a/extra_views/generic.py
+++ b/extra_views/generic.py
@@ -11,29 +11,8 @@ from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, Bas
 class BaseGenericInlineFormSetMixin(BaseInlineFormSetMixin):
     """
     Base class for constructing an generic inline formset within a view
-
-    IMPORTANT: Because of a Django bug, initial data doesn't work here.
     """
-
-    ct_field = "content_type"
-    ct_fk_field = "object_id"
     formset_class = BaseGenericInlineFormSet
-
-    def get_formset_kwargs(self):
-        kwargs = super(BaseGenericInlineFormSetMixin, self).get_formset_kwargs()
-        return kwargs
-
-    def get_factory_kwargs(self):
-        """
-        Returns the keyword arguments for calling the formset factory
-        """
-        kwargs = super(BaseGenericInlineFormSetMixin, self).get_factory_kwargs()
-        del kwargs['fk_name']
-        kwargs.update({
-            "ct_field": self.ct_field,
-            "fk_field": self.ct_fk_field,
-        })
-        return kwargs
 
     def get_formset(self):
         """

--- a/extra_views_tests/forms.py
+++ b/extra_views_tests/forms.py
@@ -33,5 +33,4 @@ class AddressForm(forms.Form):
     postcode = forms.CharField(max_length=10, required=True)
 
     def __init__(self, *args, **kwargs):
-        self.user = kwargs.pop('user')
         super(AddressForm, self).__init__(*args, **kwargs)

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -97,10 +97,6 @@ class FormSetViewTests(TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.context['formset'].management_form.auto_id,
                          'id_test_%s')
-
-    def test_extra_form_kwargs(self):
-        res = self.client.get('/formset/simple/kwargs/')
-        self.assertEqual(res.status_code, 200)
         initial_forms = res.context['formset'].initial_forms
         self.assertTrue(initial_forms)
         self.assertTrue(initial_forms[0].empty_permitted)

--- a/extra_views_tests/urls.py
+++ b/extra_views_tests/urls.py
@@ -4,15 +4,18 @@ from .formsets import AddressFormSet
 from .views import AddressFormSetView, AddressFormSetViewNamed, ItemModelFormSetView, \
     FormAndFormSetOverrideView, PagedModelFormSetView, OrderItemFormSetView, \
     OrderCreateView, OrderUpdateView, OrderTagsView, EventCalendarView, OrderCreateNamedView, \
-    SortableItemListView, SearchableItemListView
+    SortableItemListView, SearchableItemListView, AddressFormSetViewKwargs, \
+    ItemModelFormSetExcludeView
 
 urlpatterns = [
     url(r'^formset/simple/$', AddressFormSetView.as_view()),
     url(r'^formset/simple/named/$', AddressFormSetViewNamed.as_view()),
+    url(r'^formset/simple/kwargs/$', AddressFormSetViewKwargs.as_view()),
     url(r'^formset/simple_redirect/$', AddressFormSetView.as_view(success_url="/formset/simple_redirect/valid/")),
     url(r'^formset/simple_redirect/valid/$', TemplateView.as_view(template_name='extra_views/success.html')),
     url(r'^formset/custom/$', AddressFormSetView.as_view(formset_class=AddressFormSet)),
     url(r'^modelformset/simple/$', ItemModelFormSetView.as_view()),
+    url(r'^modelformset/exclude/$', ItemModelFormSetExcludeView.as_view()),
     url(r'^modelformset/custom/$', FormAndFormSetOverrideView.as_view()),
     url(r'^modelformset/paged/$', PagedModelFormSetView.as_view()),
     url(r'^inlineformset/(?P<pk>\d+)/$', OrderItemFormSetView.as_view()),

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -19,13 +19,11 @@ class AddressFormSetViewKwargs(FormSetView):
     # Used for testing class level kwargs
     form_class = AddressForm
     template_name = 'extra_views/address_formset.html'
-    formset_kwargs = {'auto_id': 'id_test_%s'}
+    formset_kwargs = {'auto_id': 'id_test_%s',
+                      'form_kwargs': {'empty_permitted': True}}
     factory_kwargs = {'max_num': 27}
     prefix = 'test_prefix'
     initial = [{'name': 'address1'}]
-
-    def get_extra_form_kwargs(self):
-        return {'empty_permitted': True}
 
 
 class ItemModelFormSetView(ModelFormSetView):

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -10,19 +10,33 @@ class AddressFormSetView(FormSetView):
     form_class = AddressForm
     template_name = 'extra_views/address_formset.html'
 
-    def get_extra_form_kwargs(self):
-        return {
-            'user': 'foo',
-        }
-
 
 class AddressFormSetViewNamed(NamedFormsetsMixin, AddressFormSetView):
     inlines_names = ['AddressFormset']
 
 
+class AddressFormSetViewKwargs(FormSetView):
+    # Used for testing class level kwargs
+    form_class = AddressForm
+    template_name = 'extra_views/address_formset.html'
+    formset_kwargs = {'auto_id': 'id_test_%s'}
+    factory_kwargs = {'max_num': 27}
+    prefix = 'test_prefix'
+    initial = [{'name': 'address1'}]
+
+    def get_extra_form_kwargs(self):
+        return {'empty_permitted': True}
+
+
 class ItemModelFormSetView(ModelFormSetView):
     model = Item
     fields = ['name', 'sku', 'price', 'order', 'status']
+    template_name = 'extra_views/item_formset.html'
+
+
+class ItemModelFormSetExcludeView(ModelFormSetView):
+    model = Item
+    exclude = ['sku', 'price']
     template_name = 'extra_views/item_formset.html'
 
 
@@ -85,6 +99,7 @@ class OrderTagsView(GenericInlineFormSetView):
     model = Order
     inline_model = Tag
     template_name = "extra_views/inline_formset.html"
+    initial = [{'name': 'test_tag_name'}]
 
 
 class EventCalendarView(CalendarMonthView):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py{27}-django{17,18,19,110,111}
-          py{34,35,36}-django{18,19,110,111}
+envlist = py{27}-django{19,110,111}
+          py{34,35,36}-django{19,110,111}
           py{35,36}-djangomaster
           docs
 
@@ -13,8 +13,6 @@ commands =
 deps =
     coverage
     django-nose
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12


### PR DESCRIPTION
An up to date pull request for #115. Also addresses #123. A few notes on what I've done here:

- Wherever possible. attempted to imitate functionality from `FormView`. That means calling `get_initial` and `get_prefix` to get class level attributes, but leaving all other kwargs to be set in either `formset_kwargs` or `factory_kwargs`.  `exclude` and `fields` have been left at the class level for analogous reasons.
- When setting mutable attributes at the class level, returning a copy of them to prevent them being modified.
- `can_delete` is set to the default value automatically by the respective formset_factory of the class, so there is no need for us to set it by default.

I was hoping to remove `get_extra_form_kwargs` completely but we need to wait until support is dropped for django 1.8.