### PR TITLE
Removed support for Django 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ python:
   - "3.6"
 
 env:
-  - DJANGO=django19
-  - DJANGO=django110
   - DJANGO=django111
+  - DJANGO=django20
   - DJANGO=djangomaster
 
 matrix:
   exclude:
+    - python: "2.7"
+      env: DJANGO=django20
     - python: "2.7"
       env: DJANGO=djangomaster
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
   - "3.6"
 
 env:
-  - DJANGO=django17
-  - DJANGO=django18
   - DJANGO=django19
   - DJANGO=django110
   - DJANGO=django111
@@ -19,12 +17,6 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO=djangomaster
-    - python: "3.4"
-      env: DJANGO=django17
-    - python: "3.5"
-      env: DJANGO=django17
-    - python: "3.6"
-      env: DJANGO=django17
   allow_failures:
     - env: DJANGO=djangomaster
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,17 +1,23 @@
 Change History
 ==============
 
-0.10.0 (2018-02-28)
-------------------
+0.xx.0
+------
 Supported Versions:
 
 ========== ==========
 python     Django
 ========== ==========
-2.7        1.7 - 1.11
-3.4 - 3.6  1.8 - 1.11
+2.7        1.9 - 1.11
+3.4 - 3.6  1.9 - 1.11
 ========== ==========
 
+Backwards-incompatible changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Dropped support for Django 1.7 and 1.8.
+
+0.10.0 (2018-02-28)
+------------------
 New features:
 
 - Added SuccessMessageWithInlinesMixin (#151)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,13 +8,13 @@ Supported Versions:
 ========== ==========
 python     Django
 ========== ==========
-2.7        1.9 - 1.11
-3.4 - 3.6  1.9 - 1.11
+2.7        1.11
+3.4 - 3.6  1.11 - 2.0
 ========== ==========
 
 Backwards-incompatible changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Dropped support for Django 1.7 and 1.8.
+- Dropped support for Django 1.7–1.10.
 
 0.10.0 (2018-02-28)
 ------------------

--- a/extra_views/generic.py
+++ b/extra_views/generic.py
@@ -1,11 +1,9 @@
 import django
+from django.contrib.contenttypes.forms import generic_inlineformset_factory, \
+    BaseGenericInlineFormSet
 
-if django.VERSION < (1, 8):
-    from django.contrib.contenttypes.generic import generic_inlineformset_factory, BaseGenericInlineFormSet
-else:
-    from django.contrib.contenttypes.forms import generic_inlineformset_factory, BaseGenericInlineFormSet
-
-from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, BaseInlineFormSetView, InlineFormSetView
+from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, \
+    BaseInlineFormSetView, InlineFormSetView
 
 
 class BaseGenericInlineFormSetMixin(BaseInlineFormSetMixin):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.10.0',
     url='https://github.com/AndrewIngram/django-extra-views',
     install_requires=[
-        'Django >=1.9',
+        'Django >=1.11',
         'six>=1.5.2',
     ],
     description="Extra class-based views for Django",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.10.0',
     url='https://github.com/AndrewIngram/django-extra-views',
     install_requires=[
-        'Django >=1.6',
+        'Django >=1.9',
         'six>=1.5.2',
     ],
     description="Extra class-based views for Django",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py{27}-django{17,18,19,110,111}
-          py{34,35,36}-django{18,19,110,111}
+envlist = py{27}-django{19,110,111}
+          py{34,35,36}-django{19,110,111}
           py{35,36}-djangomaster
           docs
 
@@ -13,8 +13,6 @@ commands =
 deps =
     coverage
     django-nose
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py{27}-django{19,110,111}
-          py{34,35,36}-django{19,110,111}
+envlist = py{27}-django{111}
+          py{34,35,36}-django{20}
           py{35,36}-djangomaster
           docs
 
@@ -13,9 +13,8 @@ commands =
 deps =
     coverage
     django-nose
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django20: Django>=2.0<2.1
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:docs]


### PR DESCRIPTION
This is the first time I've done one of these so if there's anything obvious I've missed, let me know. I've left the actual release number and date unchanged...