### PR TITLE
Fix for Django 2.0 tests

### DIFF
--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -76,7 +76,7 @@ class OrderCreateView(CreateWithInlinesView):
     template_name = 'extra_views/order_and_items.html'
 
     def get_success_url(self):
-        return '/inlines/%i' % self.object.pk
+        return '/inlines/%i/' % self.object.pk
 
 
 class OrderCreateNamedView(NamedFormsetsMixin, OrderCreateView):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py{27}-django{111}
-          py{34,35,36}-django{20}
+          py{34,35,36}-django{111,20}
           py{35,36}-djangomaster
           docs
 


### PR DESCRIPTION
Looks like Django 2.0 is more strict about using trailing slashes...and I added Django 1.11 back into the tox test environment for Python 3.