### PR TITLE
Simple clean up changes.

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -5,7 +5,6 @@ from django.forms.formsets import formset_factory
 from django.forms.models import modelformset_factory, inlineformset_factory
 from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateResponseMixin
 from django.views.generic.list import MultipleObjectMixin, MultipleObjectTemplateResponseMixin
-from django.forms.models import BaseInlineFormSet
 
 
 class BaseFormSetMixin(object):
@@ -16,7 +15,6 @@ class BaseFormSetMixin(object):
     initial = []
     form_class = None
     formset_class = None
-    success_url = None
     prefix = None
     formset_kwargs = {}
     factory_kwargs = {}
@@ -106,6 +104,7 @@ class FormSetMixin(BaseFormSetMixin, ContextMixin):
     """
     A mixin that provides a way to show and handle a formset in a request.
     """
+    success_url = None
 
     def get_success_url(self):
         """
@@ -140,25 +139,6 @@ class ModelFormSetMixin(FormSetMixin, MultipleObjectMixin):
     exclude = None
     fields = None
 
-    def get_context_data(self, **kwargs):
-        """
-        If an object list has been supplied, inject it into the context with the
-        supplied context_object_name name.
-        """
-        context = {}
-
-        if self.object_list is not None:
-            context['object_list'] = self.object_list
-            context_object_name = self.get_context_object_name(self.object_list)
-            if context_object_name:
-                context[context_object_name] = self.object_list
-        context.update(kwargs)
-
-        # MultipleObjectMixin get_context_data() doesn't work when object_list
-        # is not provided in kwargs, so we skip MultipleObjectMixin and call
-        # ContextMixin directly.
-        return ContextMixin.get_context_data(self, **context)
-
     def get_formset_kwargs(self):
         """
         Returns the keyword arguments for instantiating the formset.
@@ -177,8 +157,6 @@ class ModelFormSetMixin(FormSetMixin, MultipleObjectMixin):
 
         if self.get_form_class():
             kwargs['form'] = self.get_form_class()
-        if self.get_formset_class():
-            kwargs['formset'] = self.get_formset_class()
         return kwargs
 
     def get_formset(self):
@@ -201,24 +179,8 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
     """
     model = None
     inline_model = None
-    formset_class = BaseInlineFormSet
     exclude = None
     fields = None
-
-    def get_context_data(self, **kwargs):
-        """
-        If an object has been supplied, inject it into the context with the
-        supplied context_object_name name.
-        """
-        context = {}
-
-        if self.object:
-            context['object'] = self.object
-            context_object_name = self.get_context_object_name(self.object)
-            if context_object_name:
-                context[context_object_name] = self.object
-        context.update(kwargs)
-        return super(BaseInlineFormSetMixin, self).get_context_data(**context)
 
     def get_inline_model(self):
         """
@@ -251,8 +213,6 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
 
         if self.get_form_class():
             kwargs['form'] = self.get_form_class()
-        if self.get_formset_class():
-            kwargs['formset'] = self.get_formset_class()
         return kwargs
 
     def get_formset(self):
@@ -262,7 +222,7 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         return inlineformset_factory(self.model, self.get_inline_model(), **self.get_factory_kwargs())
 
 
-class InlineFormSetMixin(BaseInlineFormSetMixin, FormSetMixin, SingleObjectMixin):
+class InlineFormSetMixin(BaseInlineFormSetMixin, SingleObjectMixin, FormSetMixin):
     """
     A mixin that provides a way to show and handle a inline formset in a request.
     """

--- a/extra_views/generic.py
+++ b/extra_views/generic.py
@@ -1,6 +1,5 @@
 import django
-from django.contrib.contenttypes.forms import generic_inlineformset_factory, \
-    BaseGenericInlineFormSet
+from django.contrib.contenttypes.forms import generic_inlineformset_factory
 
 from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, \
     BaseInlineFormSetView, InlineFormSetView
@@ -10,7 +9,6 @@ class BaseGenericInlineFormSetMixin(BaseInlineFormSetMixin):
     """
     Base class for constructing an generic inline formset within a view
     """
-    formset_class = BaseGenericInlineFormSet
 
     def get_formset(self):
         """


### PR DESCRIPTION
1. Moved BaseFormSetMixin.success_url to FormSetMixin.success_url, as this specifically relates to functionality of a subclassed view.
2. Removed ModelFormSetMixin.get_context_data() method as django now uses self.object_list correctly (rather than requiring it to be in **kwargs which was previously the case).
3. ModelFormSetMixin.get_factory_kwargs and InlineFormSetMixin.get_factory_kwargs were both calling self().get_formset_class() a second time even though this would already have been called by BaseFormSetMixin.factory_kwargs() as part of the super() call. The extra calls have been removed.
4. Removed explicit setting of BaseInlineFormSetMixin.formset_class and GenericInlineFormSetMixin.formset_class as the defaults for inlineformset_factory and genericinlineformset_factory set this automatically.
5. Removed BaseInlineFormSetMixin.get_context_data as this will already be set by SingleObjectMixin.get_context_data when subclassed.
6. Switched subclassing of InlineFormSetMixin so that SingleObjectMixin.get_context_data will be called ahead of FormSetMixin.get_context_data (as ContextMixin.get_context_data does not super() itself).