### PR TITLE
Renamed InlineFormSet to InlineFormSetFactory and other renames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,18 @@ Change History
 0.12.0 (?)
 -------------------
 
-Clean up:
+Changes:
 - Removed setting of ``BaseInlineFormSetMixin.formset_class`` and
   ``GenericInlineFormSetMixin.formset_class`` so that ``formset`` can be set in
   ``factory_kwargs`` instead.
 - Removed ``ModelFormSetMixin.get_context_data`` and
   ``BaseInlineFormSetMixin.get_context_data`` as this code was duplicated from
   Django's ``MultipleObjectMixin`` and ``SingleObjectMixin`` respectively.
+- Renamed ``BaseFormSetMixin`` to ``BaseFormSetFactory``.
+- Renamed ``BaseInlineFormSetMixin`` to ``BaseInlineFormSetFactory``.
+- Renamed ``InlineFormSet`` to ``InlineFormSetFactory``.
+- Renamed ``BaseGenericInlineFormSetMixin`` to ``BaseGenericInlineFormSetFactory``.
+- Renamed ``GenericInlineFormSet`` to ``GenericInlineFormSetFactory``.
 
 
 0.11.0 (2018-04-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Change History
 ==============
 
+0.12.0 (?)
+-------------------
+
+Clean up:
+- Removed setting of ``BaseInlineFormSetMixin.formset_class`` and
+  ``GenericInlineFormSetMixin.formset_class`` so that ``formset`` can be set in
+  ``factory_kwargs`` instead.
+- Removed ``ModelFormSetMixin.get_context_data`` and
+  ``BaseInlineFormSetMixin.get_context_data`` as this code was duplicated from
+  Django's ``MultipleObjectMixin`` and ``SingleObjectMixin`` respectively.
+
+
 0.11.0 (2018-04-24)
 -------------------
 Supported Versions:
@@ -30,7 +42,7 @@ Backwards-incompatible changes
 New features:
 
 - Added SuccessMessageWithInlinesMixin (#151)
-- Allow the formset prefix to be overrideen (#154)
+- Allow the formset prefix to be overridden (#154)
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -75,16 +75,16 @@ Defining a CreateWithInlinesView and an UpdateWithInlinesView.
 
 .. code-block:: python
 
-    from extra_views import CreateWithInlinesView, UpdateWithInlinesView, InlineFormSet
-    from extra_views.generic import GenericInlineFormSet
+    from extra_views import CreateWithInlinesView, UpdateWithInlinesView, InlineFormSetFactory
+    from extra_views.generic import GenericInlineFormSetFactory
 
 
-    class ItemInline(InlineFormSet):
+    class ItemInline(InlineFormSetFactory):
         model = Item
         fields = '__all__'
 
 
-    class TagInline(GenericInlineFormSet):
+    class TagInline(GenericInlineFormSetFactory):
         model = Tag
         fields = '__all__'
 

--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -5,17 +5,13 @@ formset_class
 -------------
 
 The :code:`formset_class` option should be used if you intend to customize your
-:code:`InlineFormSet` and its associated formset methods.
-
-As the :code:`InlineFormSet` isn't actually a sub-class of the Django
-`BaseInlineFormSet <https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#django.forms.models.BaseInlineFormSet>`_, to achieve that, you need to define your own formset
-class which extends the Django :code:`BaseInlineFormSet`.
+:code:`InlineFormSetFactory` and its associated formset methods.
 
 For example, imagine you'd like to add your custom :code:`clean` method
 for a formset. Then, define a custom formset class, a subclass of Django
 :code:`BaseInlineFormSet`, like this::
 
-    from django.db import models
+    from django.forms.models import BaseInlineFormSet
 
     class MyCustomInlineFormSet(BaseInlineFormSet):
 
@@ -24,15 +20,14 @@ for a formset. Then, define a custom formset class, a subclass of Django
             # Your custom clean logic goes here
 
 
-Now, in your :code:`InlineFormSet` sub-class, use your formset class via
+Now, in your :code:`InlineFormSetFactory` sub-class, use your formset class via
 :code:`formset_class` setting, like this::
 
-    from extra_views import InlineFormSet
+    from extra_views import InlineFormSetFactory
 
-    class MyInlineFormSet(InlineFormSet):
+    class MyInline(InlineFormSetFactory):
         model = SomeModel
         form_class = SomeForm
         formset_class = MyCustomInlineFormSet     # enables our custom inline
 
-This will enable :code:`clean` method being executed on your
-:code:`MyInLineFormSet`.
+This will enable :code:`clean` method being executed on your :code:`MyInline`.

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -144,15 +144,15 @@ be passed to the template as context variable `inlines`.
 Here is a simple example that demonstrates the use of each view with both normal
 inline relationships and generic inlines::
 
-    from extra_views import InlineFormSet, CreateWithInlinesView, UpdateWithInlinesView
-    from extra_views.generic import GenericInlineFormSet
+    from extra_views import InlineFormSetFactory, CreateWithInlinesView, UpdateWithInlinesView
+    from extra_views.generic import GenericInlineFormSetFactory
 
 
-    class ItemsInline(InlineFormSet):
+    class ItemsInline(InlineFormSetFactory):
         model = Item
 
 
-    class TagsInline(GenericInlineFormSet):
+    class TagsInline(GenericInlineFormSetFactory):
         model = Tag
 
 

--- a/extra_views/__init__.py
+++ b/extra_views/__init__.py
@@ -1,5 +1,7 @@
-from extra_views.formsets import FormSetView, ModelFormSetView, InlineFormSetView
-from extra_views.advanced import CreateWithInlinesView, UpdateWithInlinesView, InlineFormSet, NamedFormsetsMixin
+from extra_views.formsets import FormSetView, ModelFormSetView, \
+    InlineFormSetView, BaseFormSetMixin, BaseInlineFormSetMixin
+from extra_views.advanced import CreateWithInlinesView, \
+    UpdateWithInlinesView, InlineFormSetFactory, NamedFormsetsMixin, InlineFormSet
 from extra_views.dates import CalendarMonthView
 from extra_views.contrib.mixins import SearchableListMixin, SortableListMixin
 

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -2,14 +2,18 @@ import django
 from django.views.generic.base import ContextMixin
 from django.views.generic.edit import FormView, ModelFormMixin
 from django.views.generic.detail import SingleObjectTemplateResponseMixin
-from extra_views.formsets import BaseInlineFormSetMixin
 from django.http import HttpResponseRedirect
 from django.forms.formsets import all_valid
 
+from extra_views.formsets import BaseInlineFormSetFactory
 
-class InlineFormSet(BaseInlineFormSetMixin):
+
+class InlineFormSetFactory(BaseInlineFormSetFactory):
     """
-    Base class for constructing an inline formset within a view
+    Class used to create an `InlineFormSet` from `inlineformset_factory` as
+    one of multiple `InlineFormSet`s within a single view.
+
+    Subclasses `BaseInlineFormSetFactory` and passes in the necessary view arguments.
     """
 
     def __init__(self, parent_model, request, instance, view_kwargs=None, view=None):
@@ -25,15 +29,25 @@ class InlineFormSet(BaseInlineFormSetMixin):
         Overrides construct_formset to attach the model class as
         an attribute of the returned formset instance.
         """
-        formset = super(InlineFormSet, self).construct_formset()
+        formset = super(InlineFormSetFactory, self).construct_formset()
         formset.model = self.inline_model
         return formset
+
+
+class InlineFormSet(InlineFormSetFactory):
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+        warn('`extra_views.InlineFormSet` has been renamed to `InlineFormSetFactory`. '
+             '`InlineFormSet` will be removed in a future release.', DeprecationWarning)
+        super(InlineFormSet, self).__init__(*args, **kwargs)
 
 
 class ModelFormWithInlinesMixin(ModelFormMixin):
     """
     A mixin that provides a way to show and handle a modelform and inline
     formsets in a request.
+
+    The inlines should be subclasses of `InlineFormSetFactory`.
     """
     inlines = []
 

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -7,9 +7,11 @@ from django.views.generic.detail import SingleObjectMixin, SingleObjectTemplateR
 from django.views.generic.list import MultipleObjectMixin, MultipleObjectTemplateResponseMixin
 
 
-class BaseFormSetMixin(object):
+class BaseFormSetFactory(object):
     """
-    Base class for constructing a FormSet within a view
+    Base class for constructing a FormSet from `formset_factory` in a view.
+
+    Calling `construct_formset` calls all other methods.
     """
 
     initial = []
@@ -100,9 +102,18 @@ class BaseFormSetMixin(object):
         return kwargs
 
 
-class FormSetMixin(BaseFormSetMixin, ContextMixin):
+class BaseFormSetMixin(BaseFormSetFactory):
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+        warn('`extra_views.BaseFormSetMixin` has been renamed to '
+             '`BaseFormSetFactory`. `BaseFormSetMixin` will be removed in '
+             'a future release.', DeprecationWarning)
+        super(BaseFormSetMixin, self).__init__(*args, **kwargs)
+
+
+class FormSetMixin(BaseFormSetFactory, ContextMixin):
     """
-    A mixin that provides a way to show and handle a formset in a request.
+    A view mixin that provides a way to show and handle a single formset in a request.
     """
     success_url = None
 
@@ -133,7 +144,9 @@ class FormSetMixin(BaseFormSetMixin, ContextMixin):
 
 class ModelFormSetMixin(FormSetMixin, MultipleObjectMixin):
     """
-    A mixin that provides a way to show and handle a model formset in a request.
+    A view mixin that provides a way to show and handle a single model formset in a request.
+
+    Uses `modelformset_factory`.
     """
 
     exclude = None
@@ -173,9 +186,11 @@ class ModelFormSetMixin(FormSetMixin, MultipleObjectMixin):
         return super(ModelFormSetMixin, self).formset_valid(formset)
 
 
-class BaseInlineFormSetMixin(BaseFormSetMixin):
+class BaseInlineFormSetFactory(BaseFormSetFactory):
     """
-    Base class for constructing an inline formSet within a view
+    Base class for constructing a FormSet from `inlineformset_factory` in a view.
+
+    Calling `construct_formset` calls all other methods.
     """
     model = None
     inline_model = None
@@ -199,7 +214,7 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
                 'Setting `{0}.save_as_new` at the class level is now '
                 'deprecated. Set `{0}.formset_kwargs` instead.'.format(klass)
             )
-        kwargs = super(BaseInlineFormSetMixin, self).get_formset_kwargs()
+        kwargs = super(BaseInlineFormSetFactory, self).get_formset_kwargs()
         kwargs['instance'] = self.object
         return kwargs
 
@@ -207,7 +222,7 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         """
         Returns the keyword arguments for calling the formset factory
         """
-        kwargs = super(BaseInlineFormSetMixin, self).get_factory_kwargs()
+        kwargs = super(BaseInlineFormSetFactory, self).get_factory_kwargs()
         kwargs.setdefault('fields', self.fields)
         kwargs.setdefault('exclude', self.exclude)
 
@@ -222,9 +237,18 @@ class BaseInlineFormSetMixin(BaseFormSetMixin):
         return inlineformset_factory(self.model, self.get_inline_model(), **self.get_factory_kwargs())
 
 
-class InlineFormSetMixin(BaseInlineFormSetMixin, SingleObjectMixin, FormSetMixin):
+class BaseInlineFormSetMixin(BaseInlineFormSetFactory):
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+        warn('`extra_views.BaseInlineFormSetMixin` has been renamed to '
+             '`BaseInlineFormSetFactory`. `BaseInlineFormSetMixin` will be removed in '
+             'a future release.', DeprecationWarning)
+        super(BaseInlineFormSetMixin, self).__init__(*args, **kwargs)
+
+
+class InlineFormSetMixin(BaseInlineFormSetFactory, SingleObjectMixin, FormSetMixin):
     """
-    A mixin that provides a way to show and handle a inline formset in a request.
+    A view mixin that provides a way to show and handle a single inline formset in a request.
     """
 
     def formset_valid(self, formset):

--- a/extra_views/generic.py
+++ b/extra_views/generic.py
@@ -1,26 +1,39 @@
 import django
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 
-from extra_views.formsets import BaseInlineFormSetMixin, InlineFormSetMixin, \
+from extra_views.formsets import BaseInlineFormSetFactory, InlineFormSetMixin, \
     BaseInlineFormSetView, InlineFormSetView
 
 
-class BaseGenericInlineFormSetMixin(BaseInlineFormSetMixin):
+class BaseGenericInlineFormSetFactory(BaseInlineFormSetFactory):
     """
-    Base class for constructing an generic inline formset within a view
+    Base class for constructing a GenericInlineFormSet from
+    `generic_inlineformset_factory` in a view.
     """
 
     def get_formset(self):
         """
-        Returns the final formset class from the inline formset factory
+        Returns the final formset class from generic_inlineformset_factory.
         """
         result = generic_inlineformset_factory(self.inline_model, **self.get_factory_kwargs())
         return result
 
 
-class GenericInlineFormSet(BaseGenericInlineFormSetMixin):
+class BaseGenericInlineFormSetMixin(BaseGenericInlineFormSetFactory):
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+        warn('`extra_views.BaseGenericInlineFormSetMixin` has been renamed to '
+             '`BaseGenericInlineFormSetFactory`. `BaseGenericInlineFormSetMixin` '
+             'will be removed in a future release.', DeprecationWarning)
+        super(BaseGenericInlineFormSetMixin, self).__init__(*args, **kwargs)
+
+
+class GenericInlineFormSetFactory(BaseGenericInlineFormSetFactory):
     """
-    An inline class that provides a way to handle generic inline formsets
+    Class used to create a `GenericInlineFormSet` from `generic_inlineformset_factory`
+    as one of multiple `GenericInlineFormSet`s within a single view.
+
+    Subclasses `BaseGenericInlineFormSetFactory` and passes in the necessary view arguments.
     """
 
     def __init__(self, parent_model, request, instance, view_kwargs=None, view=None):
@@ -32,7 +45,16 @@ class GenericInlineFormSet(BaseGenericInlineFormSetMixin):
         self.view = view
 
 
-class GenericInlineFormSetMixin(BaseGenericInlineFormSetMixin, InlineFormSetMixin):
+class GenericInlineFormSet(GenericInlineFormSetFactory):
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+        warn('`extra_views.GenericInlineFormSet` has been renamed to '
+             '`GenericInlineFormSetFactory`. `GenericInlineFormSet` '
+             'will be removed in a future release.', DeprecationWarning)
+        super(GenericInlineFormSet, self).__init__(*args, **kwargs)
+
+
+class GenericInlineFormSetMixin(BaseGenericInlineFormSetFactory, InlineFormSetMixin):
     """
     A mixin that provides a way to show and handle a generic inline formset in a request.
     """

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -1,5 +1,5 @@
-from extra_views import FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSet, CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView, NamedFormsetsMixin, SortableListMixin, SearchableListMixin
-from extra_views.generic import GenericInlineFormSet, GenericInlineFormSetView
+from extra_views import FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSetFactory, CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView, NamedFormsetsMixin, SortableListMixin, SearchableListMixin
+from extra_views.generic import GenericInlineFormSetFactory, GenericInlineFormSetView
 from django.views import generic
 from .forms import AddressForm, ItemForm, OrderForm
 from .formsets import BaseArticleFormSet
@@ -58,12 +58,12 @@ class PagedModelFormSetView(ModelFormSetView):
     template_name = 'extra_views/paged_formset.html'
 
 
-class ItemsInline(InlineFormSet):
+class ItemsInline(InlineFormSetFactory):
     model = Item
     fields = ['name', 'sku', 'price', 'order', 'status']
 
 
-class TagsInline(GenericInlineFormSet):
+class TagsInline(GenericInlineFormSetFactory):
     model = Tag
     fields = ['name']
 


### PR DESCRIPTION
Let me know if the way I've handled the deprecation warnings is OK; I assumed just checking on ``__init__`` would be sufficient.
#165.