### PR TITLE
Test that get_absolute_url() is used in success_url of Create/UpdateWithInlinesView

### DIFF
--- a/extra_views_tests/models.py
+++ b/extra_views_tests/models.py
@@ -24,6 +24,12 @@ class Order(models.Model):
     date_modified = models.DateTimeField(auto_now=True)
     action_on_save = models.BooleanField(default=False)
 
+    def get_absolute_url(self):
+        return '/inlines/%i/' % self.pk
+
+    def __str__(self):
+        return self.name
+
 
 class Item(models.Model):
     name = models.CharField(max_length=255)

--- a/extra_views_tests/models.py
+++ b/extra_views_tests/models.py
@@ -3,14 +3,11 @@ try:
     from django.utils.timezone import now
 except ImportError:
     now = datetime.datetime.now
-import django
+
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 
-if django.VERSION < (1, 8):
-    from django.contrib.contenttypes.generic import GenericForeignKey
-else:
-    from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey
 
 STATUS_CHOICES = (
     (0, 'Placed'),
@@ -36,7 +33,7 @@ class Item(models.Model):
     status = models.SmallIntegerField(default=0, choices=STATUS_CHOICES, db_index=True)
     date_placed = models.DateField(default=now, null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s (%s)' % (self.name, self.sku)
 
 
@@ -45,7 +42,7 @@ class Contact(models.Model):
     email = models.CharField(max_length=255)
     order = models.ForeignKey(Order, related_name='contacts', on_delete=models.CASCADE)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -55,7 +52,7 @@ class Tag(models.Model):
     object_id = models.PositiveIntegerField(null=True)
     content_object = GenericForeignKey('content_type', 'object_id')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -63,5 +60,5 @@ class Event(models.Model):
     name = models.CharField(max_length=255)
     date = models.DateField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -8,10 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
 from django.test import TestCase
 
-if django.VERSION < (1, 8):
-    from django.utils.unittest import expectedFailure
-else:
-    from unittest import expectedFailure
+from unittest import expectedFailure
 
 from .models import Item, Order, Tag, Event
 

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -414,6 +414,8 @@ class ModelWithInlinesTests(TestCase):
 
         res = self.client.post('/inlines/{}/'.format(order.id), data)
         self.assertEqual(res.status_code, 302)
+        # Test that the returned url is the same as the instances absolute url.
+        self.assertEqual(res.url, order.get_absolute_url())
 
         order = Order.objects.get(id=order.id)
 

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -75,9 +75,6 @@ class OrderCreateView(CreateWithInlinesView):
     inlines = [ItemsInline, TagsInline]
     template_name = 'extra_views/order_and_items.html'
 
-    def get_success_url(self):
-        return '/inlines/%i/' % self.object.pk
-
 
 class OrderCreateNamedView(NamedFormsetsMixin, OrderCreateView):
     inlines_names = ['Items', 'Tags']
@@ -88,9 +85,6 @@ class OrderUpdateView(UpdateWithInlinesView):
     form_class = OrderForm
     inlines = [ItemsInline, TagsInline]
     template_name = 'extra_views/order_and_items.html'
-
-    def get_success_url(self):
-        return ''
 
 
 class OrderTagsView(GenericInlineFormSetView):


### PR DESCRIPTION
As per #92. This happens automatically because our `ModelFormWithInlinesMixin` inherits from Django's `ModelFormMixin` which correctly uses `get_absolute_url()` for the success_url.