### PR TITLE
Complete Messages Mixin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change History
 ==============
 
+0.13.0 (not yet released)
+-------------------------
+
+Changes:
+~~~~~~~~
+- Added ``SuccessMessageMixin`` and ``FormSetSuccessMessageMixin``.
+
 0.12.0 (2018-10-21)
 -------------------
 Supported Versions:

--- a/docs/pages/formset-customization.rst
+++ b/docs/pages/formset-customization.rst
@@ -159,3 +159,52 @@ Then use the appropriate names to render them in the html template:
     ...
     {{ Items }}
     ...
+
+Success messages
+----------------
+When using Django's `django.contrib.messages` framework, mixins are available in
+order to send success messages in a similar way to
+`django.contrib.messages.views.SuccessMessageMixin`. Ensure that
+`'django.contrib.messages.middleware.MessageMiddleware'` is included in the
+`MIDDLEWARE` section of `settings.py`.
+
+`extra_views.SuccessMessageMixin` is for use with views with multiple
+inline formsets. It is used in an identical manner to the Django mixin:
+
+.. code-block:: python
+
+    from extra_views import CreateWithInlinesView, SuccessMessageMixin
+    ...
+
+    class CreateOrderView(SuccessMessageMixin, CreateWithInlinesView):
+        model = Order
+        inlines = [ItemInline, ContactInline]
+        success_message = 'Order successfully created!'
+        ...
+
+        # or instead, set at runtime:
+        def get_success_message(self, cleaned_data, inlines):
+            return 'Order with id {} successfully created'.format(self.object.pk)
+
+Note that the success message mixins should be placed ahead of the main view in
+order of class inheritance.
+
+`extra_views.FormSetSuccessMessageMixin` is for use with views which handle a single
+formset:
+
+.. code-block:: python
+
+    from extra_views import FormSetView, FormSetSuccessMessageMixin
+    from my_app.forms import AddressForm
+
+
+    class AddressFormSetView(FormSetView):
+        form_class = AddressForm
+        success_url = 'success/'
+        ...
+        success_message = 'Addresses Updated!'
+
+    # or instead, set at runtime
+    def get_success_message(self, formset)
+        # Here you can use the formset in the message if required
+        return '{} addresses were updated.'.format(len(formset.forms))

--- a/docs/pages/formset-customization.rst
+++ b/docs/pages/formset-customization.rst
@@ -169,7 +169,11 @@ order to send success messages in a similar way to
 `MIDDLEWARE` section of `settings.py`.
 
 `extra_views.SuccessMessageMixin` is for use with views with multiple
-inline formsets. It is used in an identical manner to the Django mixin:
+inline formsets. It is used in an identical manner to Django's
+SuccessMessageMixin_, making `form.cleaned_data` available for string
+interpolation using the `%(field_name)s` syntax.
+
+.. _SuccessMessageMixin: https://docs.djangoproject.com/en/dev/ref/contrib/messages/#django.contrib.messages.views.SuccessMessageMixin
 
 .. code-block:: python
 
@@ -179,7 +183,7 @@ inline formsets. It is used in an identical manner to the Django mixin:
     class CreateOrderView(SuccessMessageMixin, CreateWithInlinesView):
         model = Order
         inlines = [ItemInline, ContactInline]
-        success_message = 'Order successfully created!'
+        success_message = 'Order %(name)s successfully created!'
         ...
 
         # or instead, set at runtime:
@@ -190,7 +194,8 @@ Note that the success message mixins should be placed ahead of the main view in
 order of class inheritance.
 
 `extra_views.FormSetSuccessMessageMixin` is for use with views which handle a single
-formset:
+formset. In order to parse any data from the formset, you should override the
+`get_success_message` method as below:
 
 .. code-block:: python
 

--- a/extra_views/__init__.py
+++ b/extra_views/__init__.py
@@ -1,7 +1,8 @@
 from extra_views.formsets import FormSetView, ModelFormSetView, \
     InlineFormSetView, BaseFormSetMixin, BaseInlineFormSetMixin
 from extra_views.advanced import CreateWithInlinesView, \
-    UpdateWithInlinesView, InlineFormSetFactory, NamedFormsetsMixin, InlineFormSet
+    UpdateWithInlinesView, InlineFormSetFactory, NamedFormsetsMixin, InlineFormSet, \
+    FormSetSuccessMessageMixin, SuccessMessageMixin
 from extra_views.dates import CalendarMonthView
 from extra_views.contrib.mixins import SearchableListMixin, SortableListMixin
 

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -215,12 +215,12 @@ class SuccessMessageMixin(object):
 
     def forms_valid(self, form, inlines):
         response = super(SuccessMessageMixin, self).forms_valid(form, inlines)
-        success_message = self.get_success_message(form.cleaned_data)
+        success_message = self.get_success_message(form.cleaned_data, inlines)
         if success_message:
             messages.success(self.request, success_message)
         return response
 
-    def get_success_message(self, cleaned_data):
+    def get_success_message(self, cleaned_data, inlines):
         return self.success_message % cleaned_data
 
 

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -4,6 +4,7 @@ from django.views.generic.edit import FormView, ModelFormMixin
 from django.views.generic.detail import SingleObjectTemplateResponseMixin
 from django.http import HttpResponseRedirect
 from django.forms.formsets import all_valid
+from django.contrib import messages
 
 from extra_views.formsets import BaseInlineFormSetFactory
 
@@ -201,3 +202,43 @@ class NamedFormsetsMixin(ContextMixin):
                 context[inlines_names[0]] = kwargs['formset']
         context.update(kwargs)
         return super(NamedFormsetsMixin, self).get_context_data(**context)
+
+
+class SuccessMessageMixin(object):
+    """
+    Adds success message on views with inlines if django.contrib.messages framework is used.
+    In order to use just add mixin in to inheritance before main class, e.g.:
+    class MyCreateWithInlinesView (SuccessMessageMixin, CreateWithInlinesView):
+        success_message='Something was created!'
+    """
+    success_message = ''
+
+    def forms_valid(self, form, inlines):
+        response = super(SuccessMessageMixin, self).forms_valid(form, inlines)
+        success_message = self.get_success_message(form.cleaned_data)
+        if success_message:
+            messages.success(self.request, success_message)
+        return response
+
+    def get_success_message(self, cleaned_data):
+        return self.success_message % cleaned_data
+
+
+class FormSetSuccessMessageMixin(object):
+    """
+    Adds success message on FormSet views if django.contrib.messages framework is used.
+    In order to use just add mixin in to inheritance before main class, e.g.:
+    class MyCreateWithInlinesView (SuccessMessageMixin, ModelFormSetView):
+        success_message='Something was created!'
+    """
+    success_message = ''
+
+    def formset_valid(self, formset):
+        response = super(FormSetSuccessMessageMixin, self).formset_valid(formset)
+        success_message = self.get_success_message(formset)
+        if success_message:
+            messages.success(self.request, success_message)
+        return response
+
+    def get_success_message(self, formset):
+        return self.success_message

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -7,6 +7,7 @@ import django
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
 from django.test import TestCase
+from django.contrib.messages import get_messages
 
 from unittest import expectedFailure
 
@@ -40,6 +41,11 @@ class FormSetViewTests(TestCase):
     def test_success(self):
         res = self.client.post('/formset/simple/', self.management_data, follow=True)
         self.assertRedirects(res, '/formset/simple/', status_code=302)
+
+    def test_success_message(self):
+        res = self.client.post('/formset/simple/', self.management_data, follow=True)
+        messages = [message.__str__() for message in get_messages(res.context['view'].request)]
+        self.assertIn('Formset objects were created successfully!', messages)
 
     @expectedFailure
     def test_put(self):
@@ -329,6 +335,33 @@ class ModelWithInlinesTests(TestCase):
 
         self.assertEqual(res.status_code, 200)
         self.assertEqual(1, Tag.objects.count())
+
+    def test_create_success_message(self):
+        res = self.client.get('/inlines/new/')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(0, Tag.objects.count())
+
+        data = {
+            'name': 'Dummy Order',
+            'items-TOTAL_FORMS': '2',
+            'items-INITIAL_FORMS': '0',
+            'items-MAX_NUM_FORMS': '',
+            'items-0-name': 'Bubble Bath',
+            'items-0-sku': '1234567890123',
+            'items-0-price': D('9.99'),
+            'items-0-status': 0,
+            'items-1-DELETE': True,
+            'extra_views_tests-tag-content_type-object_id-TOTAL_FORMS': 2,
+            'extra_views_tests-tag-content_type-object_id-INITIAL_FORMS': 0,
+            'extra_views_tests-tag-content_type-object_id-MAX_NUM_FORMS': '',
+            'extra_views_tests-tag-content_type-object_id-0-name': 'Test',
+            'extra_views_tests-tag-content_type-object_id-1-DELETE': True,
+        }
+
+        res = self.client.post('/inlines/new/', data, follow=True)
+
+        messages = [message.__str__() for message in get_messages(res.context['view'].request)]
+        self.assertIn('Order Dummy Order was created successfully!', messages)
 
     def test_named_create(self):
         res = self.client.get('/inlines/new/named/')

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -1,4 +1,9 @@
-from extra_views import FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSetFactory, CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView, NamedFormsetsMixin, SortableListMixin, SearchableListMixin, SuccessMessageMixin, FormSetSuccessMessageMixin
+from extra_views import (
+    FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSetFactory,
+    CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView,
+    NamedFormsetsMixin, SortableListMixin, SearchableListMixin,
+    SuccessMessageMixin, FormSetSuccessMessageMixin
+)
 from extra_views.generic import GenericInlineFormSetFactory, GenericInlineFormSetView
 from django.views import generic
 from .forms import AddressForm, ItemForm, OrderForm

--- a/extra_views_tests/views.py
+++ b/extra_views_tests/views.py
@@ -1,4 +1,4 @@
-from extra_views import FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSetFactory, CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView, NamedFormsetsMixin, SortableListMixin, SearchableListMixin
+from extra_views import FormSetView, ModelFormSetView, InlineFormSetView, InlineFormSetFactory, CreateWithInlinesView, UpdateWithInlinesView, CalendarMonthView, NamedFormsetsMixin, SortableListMixin, SearchableListMixin, SuccessMessageMixin, FormSetSuccessMessageMixin
 from extra_views.generic import GenericInlineFormSetFactory, GenericInlineFormSetView
 from django.views import generic
 from .forms import AddressForm, ItemForm, OrderForm
@@ -6,9 +6,10 @@ from .formsets import BaseArticleFormSet
 from .models import Item, Order, Tag, Event
 
 
-class AddressFormSetView(FormSetView):
+class AddressFormSetView(FormSetSuccessMessageMixin, FormSetView):
     form_class = AddressForm
     template_name = 'extra_views/address_formset.html'
+    success_message = 'Formset objects were created successfully!'
 
 
 class AddressFormSetViewNamed(NamedFormsetsMixin, AddressFormSetView):
@@ -68,12 +69,13 @@ class TagsInline(GenericInlineFormSetFactory):
     fields = ['name']
 
 
-class OrderCreateView(CreateWithInlinesView):
+class OrderCreateView(SuccessMessageMixin, CreateWithInlinesView):
     model = Order
     fields = ['name']
     context_object_name = 'order'
     inlines = [ItemsInline, TagsInline]
     template_name = 'extra_views/order_and_items.html'
+    success_message = 'Order %(name)s was created successfully!'
 
 
 class OrderCreateNamedView(NamedFormsetsMixin, OrderCreateView):

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,15 @@ def configure(nose_args=None):
                 'extra_views',
                 'extra_views_tests',
             ],
+            MIDDLEWARE=[
+                'django.middleware.security.SecurityMiddleware',
+                'django.contrib.sessions.middleware.SessionMiddleware',
+                'django.middleware.common.CommonMiddleware',
+                'django.middleware.csrf.CsrfViewMiddleware',
+                'django.contrib.auth.middleware.AuthenticationMiddleware',
+                'django.contrib.messages.middleware.MessageMiddleware',
+                'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            ],
             ROOT_URLCONF='extra_views_tests.urls',
             NOSE_ARGS=nose_args
         )

--- a/runtests.py
+++ b/runtests.py
@@ -32,7 +32,8 @@ def configure(nose_args=None):
                 'django.middleware.clickjacking.XFrameOptionsMiddleware',
             ],
             ROOT_URLCONF='extra_views_tests.urls',
-            NOSE_ARGS=nose_args
+            NOSE_ARGS=nose_args,
+            SECRET_KEY='something not very secret'
         )
 
 


### PR DESCRIPTION
This replaces PR #147 and uses most of what @freeworlder did. I have added documentation and updated the tests.

One change I made was to add `inlines` to the arguments of `SuccessMessageMixin.get_success_message()` so that they can be used in the success message. This seemed in line with what was discussed in #59.

Apologies that the commit history is a little messy, am happy to clean it up if requested.