### PR TITLE
Revert view.object back to original value if inline validation fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Change History
 Changes:
 ~~~~~~~~
 - Added ``SuccessMessageMixin`` and ``FormSetSuccessMessageMixin``.
+- Revert ``view.object`` back to it's original value from the GET request if
+  validation fails for the inline formsets in ``CreateWithInlinesView`` and
+  ``UpdateWithInlinesview``.
 
 0.12.0 (2018-10-21)
 -------------------

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -108,6 +108,7 @@ class ProcessFormWithInlinesView(FormView):
         form_class = self.get_form_class()
         form = self.get_form(form_class)
 
+        initial_object = self.object
         if form.is_valid():
             self.object = form.save(commit=False)
             form_validated = True
@@ -118,6 +119,7 @@ class ProcessFormWithInlinesView(FormView):
 
         if all_valid(inlines) and form_validated:
             return self.forms_valid(form, inlines)
+        self.object = initial_object
         return self.forms_invalid(form, inlines)
 
     # PUT is a valid HTTP verb for creating (with a known URL) or editing an

--- a/extra_views_tests/tests.py
+++ b/extra_views_tests/tests.py
@@ -394,6 +394,35 @@ class ModelWithInlinesTests(TestCase):
         self.assertEqual(len(res.context['form'].errors), 1)
         self.assertEqual(len(res.context['inlines'][0].errors[0]), 2)
 
+    def test_view_object_is_none_after_failed_validation_for_createview(self):
+        # We are testing that view.object = None even if the form validates
+        # but one of the inline formsets does not.
+        data = {
+            'name': 'Dummy Order',
+            'items-TOTAL_FORMS': '2',
+            'items-INITIAL_FORMS': '0',
+            'items-MAX_NUM_FORMS': '',
+            'items-0-name': 'Test Item 1',
+            'items-0-sku': '',
+            'items-0-price': '',
+            'items-0-status': 0,
+            'items-1-name': '',
+            'items-1-sku': '',
+            'items-1-price': '',
+            'items-1-status': '',
+            'items-1-DELETE': True,
+            'extra_views_tests-tag-content_type-object_id-TOTAL_FORMS': 2,
+            'extra_views_tests-tag-content_type-object_id-INITIAL_FORMS': 0,
+            'extra_views_tests-tag-content_type-object_id-MAX_NUM_FORMS': '',
+            'extra_views_tests-tag-content_type-object_id-0-name': 'Test',
+            'extra_views_tests-tag-content_type-object_id-1-DELETE': True,
+        }
+
+        res = self.client.post('/inlines/new/', data, follow=True)
+        self.assertEqual(len(res.context['form'].errors), 0)
+        self.assertEqual(len(res.context['inlines'][0].errors[0]), 2)
+        self.assertEqual(res.context['view'].object, None)
+
     def test_update(self):
         order = Order(name='Dummy Order')
         order.save()


### PR DESCRIPTION
As per issue #155.

@Murfen please confirm if this resolves the issue for you.