### PR TITLE
Fix typo in tox django version spec

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps =
     coverage
     django-nose
     django111: Django>=1.11,<1.12
-    django20: Django>=2.0<2.1
-    django21: Django>=2.1<2.2
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:docs]


### PR DESCRIPTION
Missing comma, which meant that upper bound was ignored (so these were actually running with 2.2).