### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0a1,<3.1
     django31: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomaster: https://github.com/django/django/archive/main.tar.gz
     pytest-django
     pytest-cov
 


### PR DESCRIPTION
The default django repository is now called main