### PR TITLE
Fix tests for Django 3.2 and djangomaster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 env:
   - DJANGO=django21
   - DJANGO=django22
   - DJANGO=django30
   - DJANGO=django31
+  - DJANGO=django32
   - DJANGO=djangomaster
 
 matrix:
@@ -21,8 +23,16 @@ matrix:
     - python: "3.5"
       env: DJANGO=django31
     - python: "3.5"
+      env: DJANGO=django32
+    - python: "3.5"
+      env: DJANGO=djangomaster
+    - python: "3.6"
+      env: DJANGO=djangomaster
+    - python: "3.7"
       env: DJANGO=djangomaster
     - python: "3.8"
+      env: DJANGO=django21
+    - python: "3.9"
       env: DJANGO=django21
   allow_failures:
     - env: DJANGO=djangomaster

--- a/extra_views_tests/urls.py
+++ b/extra_views_tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import TemplateView
 
 from .formsets import AddressFormSet
@@ -21,37 +21,37 @@ from .views import (
 )
 
 urlpatterns = [
-    url(r"^formset/simple/$", AddressFormSetView.as_view()),
-    url(r"^formset/simple/named/$", AddressFormSetViewNamed.as_view()),
-    url(r"^formset/simple/kwargs/$", AddressFormSetViewKwargs.as_view()),
-    url(
-        r"^formset/simple_redirect/$",
+    path("formset/simple/", AddressFormSetView.as_view()),
+    path("formset/simple/named/", AddressFormSetViewNamed.as_view()),
+    path("formset/simple/kwargs/", AddressFormSetViewKwargs.as_view()),
+    path(
+        "formset/simple_redirect/",
         AddressFormSetView.as_view(success_url="/formset/simple_redirect/valid/"),
     ),
-    url(
-        r"^formset/simple_redirect/valid/$",
+    path(
+        "formset/simple_redirect/valid/",
         TemplateView.as_view(template_name="extra_views/success.html"),
     ),
-    url(r"^formset/custom/$", AddressFormSetView.as_view(formset_class=AddressFormSet)),
-    url(r"^modelformset/simple/$", ItemModelFormSetView.as_view()),
-    url(r"^modelformset/exclude/$", ItemModelFormSetExcludeView.as_view()),
-    url(r"^modelformset/custom/$", FormAndFormSetOverrideView.as_view()),
-    url(r"^modelformset/paged/$", PagedModelFormSetView.as_view()),
-    url(r"^inlineformset/(?P<pk>\d+)/$", OrderItemFormSetView.as_view()),
-    url(r"^inlines/(\d+)/new/$", OrderCreateView.as_view()),
-    url(r"^inlines/new/$", OrderCreateView.as_view()),
-    url(r"^inlines/new/named/$", OrderCreateNamedView.as_view()),
-    url(r"^inlines/(?P<pk>\d+)/$", OrderUpdateView.as_view()),
-    url(r"^genericinlineformset/(?P<pk>\d+)/$", OrderTagsView.as_view()),
-    url(r"^sortable/(?P<flag>\w+)/$", SortableItemListView.as_view()),
-    url(r"^events/(?P<year>\d{4})/(?P<month>\w+)/$", EventCalendarView.as_view()),
-    url(r"^searchable/$", SearchableItemListView.as_view()),
-    url(
-        r"^searchable/predefined_query/$",
+    path("formset/custom/", AddressFormSetView.as_view(formset_class=AddressFormSet)),
+    path("modelformset/simple/", ItemModelFormSetView.as_view()),
+    path("modelformset/exclude/", ItemModelFormSetExcludeView.as_view()),
+    path("modelformset/custom/", FormAndFormSetOverrideView.as_view()),
+    path("modelformset/paged/", PagedModelFormSetView.as_view()),
+    path("inlineformset/<int:pk>/", OrderItemFormSetView.as_view()),
+    path("inlines/<int:pk>/new/", OrderCreateView.as_view()),
+    path("inlines/new/", OrderCreateView.as_view()),
+    path("inlines/new/named/", OrderCreateNamedView.as_view()),
+    path("inlines/<int:pk>/", OrderUpdateView.as_view()),
+    path("genericinlineformset/<int:pk>/", OrderTagsView.as_view()),
+    path("sortable/<str:flag>/", SortableItemListView.as_view()),
+    path("events/<int:year>/<str:month>/", EventCalendarView.as_view()),
+    path("searchable/", SearchableItemListView.as_view()),
+    path(
+        "searchable/predefined_query/",
         SearchableItemListView.as_view(define_query=True),
     ),
-    url(r"^searchable/exact_query/$", SearchableItemListView.as_view(exact_query=True)),
-    url(
-        r"^searchable/wrong_lookup/$", SearchableItemListView.as_view(wrong_lookup=True)
+    path("searchable/exact_query/", SearchableItemListView.as_view(exact_query=True)),
+    path(
+        "searchable/wrong_lookup/", SearchableItemListView.as_view(wrong_lookup=True)
     ),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist = py35-django{21,22}
-          py36-django{21,22,30,31,master}
-          py37-django{21,22,30,31,master}
-          py38-django{22,30,31,master}
+          py36-django{21,22,30,31,32,master}
+          py37-django{21,22,30,31,32,master}
+          py38-django{22,30,31,32,master}
+          py39-django{22,30,31,32,master}
           docs
 
 [testenv]
@@ -19,6 +20,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0a1,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     djangomaster: https://github.com/django/django/archive/main.tar.gz
     pytest-django
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py35-django{21,22}
-          py36-django{21,22,30,31,32,master}
-          py37-django{21,22,30,31,32,master}
+          py36-django{21,22,30,31,32}
+          py37-django{21,22,30,31,32}
           py38-django{22,30,31,32,master}
           py39-django{22,30,31,32,master}
           docs


### PR DESCRIPTION
The management form test was broken, as Django >= 3.2 uses a formset error rather than raising an exception.
Also fixed extra_views_tests to use django.urls.path in preparation for Django 4.0, and removed Python 3.6 and 3.7 from djangomaster as Django >= 4.0 does not support them.

There's no rush to release as these are updates to the test suite and not the actual module.