### PR TITLE
Behavior of immutable attributes

### DIFF
--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.contrib import messages
 from django.forms.formsets import all_valid
 from django.views.generic.base import ContextMixin
@@ -47,7 +49,7 @@ class ModelFormWithInlinesMixin(ModelFormMixin):
         """
         Returns the inline formset classes
         """
-        return self.inlines
+        return deepcopy(self.inlines)
 
     def forms_valid(self, form, inlines):
         """
@@ -191,7 +193,7 @@ class NamedFormsetsMixin(ContextMixin):
         """
         Returns a list of names of context variables for each inline in `inlines`.
         """
-        return self.inlines_names
+        return deepcopy(self.inlines_names)
 
     def get_context_data(self, **kwargs):
         """

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -1,5 +1,3 @@
-from copy import copy
-
 from django.contrib import messages
 from django.forms.formsets import all_valid
 from django.views.generic.base import ContextMixin
@@ -49,7 +47,7 @@ class ModelFormWithInlinesMixin(ModelFormMixin):
         """
         Returns the inline formset classes
         """
-        return copy(self.inlines)
+        return self.inlines[:]
 
     def forms_valid(self, form, inlines):
         """
@@ -193,7 +191,7 @@ class NamedFormsetsMixin(ContextMixin):
         """
         Returns a list of names of context variables for each inline in `inlines`.
         """
-        return copy(self.inlines_names)
+        return self.inlines_names[:]
 
     def get_context_data(self, **kwargs):
         """

--- a/extra_views/advanced.py
+++ b/extra_views/advanced.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 
 from django.contrib import messages
 from django.forms.formsets import all_valid
@@ -49,7 +49,7 @@ class ModelFormWithInlinesMixin(ModelFormMixin):
         """
         Returns the inline formset classes
         """
-        return deepcopy(self.inlines)
+        return copy(self.inlines)
 
     def forms_valid(self, form, inlines):
         """
@@ -193,7 +193,7 @@ class NamedFormsetsMixin(ContextMixin):
         """
         Returns a list of names of context variables for each inline in `inlines`.
         """
-        return deepcopy(self.inlines_names)
+        return copy(self.inlines_names)
 
     def get_context_data(self, **kwargs):
         """


### PR DESCRIPTION
When using `get_inlines` and `get_inlines_names`, a new copy of the object is returned, avoiding changing the class attribute.