### PR TITLE
Add form_kwargs and get_form_kwargs for inline forms for solving issue #256

### DIFF
--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -25,6 +25,7 @@ class BaseFormSetFactory(object):
     prefix = None
     formset_kwargs = {}
     factory_kwargs = {}
+    form_kwargs = {}
 
     def construct_formset(self):
         """
@@ -57,6 +58,9 @@ class BaseFormSetFactory(object):
         """
         return self.form_class
 
+    def get_form_kwargs(self):
+        return self.form_kwargs
+
     def get_formset(self):
         """
         Returns the formset class from the formset factory
@@ -68,7 +72,8 @@ class BaseFormSetFactory(object):
         Returns the keyword arguments for instantiating the formset.
         """
         kwargs = self.formset_kwargs.copy()
-        kwargs.update({"initial": self.get_initial(), "prefix": self.get_prefix()})
+        kwargs.update({"initial": self.get_initial(
+        ), "prefix": self.get_prefix(), "form_kwargs": self.get_form_kwargs()})
 
         if self.request.method in ("POST", "PUT"):
             kwargs.update(


### PR DESCRIPTION
Using [this Stack Overflow answer](https://stackoverflow.com/a/35811020/8553089) and [this section of the Django documentation](https://docs.djangoproject.com/en/2.0/topics/forms/formsets/#passing-custom-parameters-to-formset-forms), I have solve [the issue](https://github.com/AndrewIngram/django-extra-views/issues/256) of missing ```form_kwargs``` as attribute of the ```formset_kwargs``` dictionary as mentioned in [ this section of the django-extra-views docs](https://django-extra-views.readthedocs.io/en/latest/pages/formset-customization.html#passing-arguments-to-the-form-constructor) . 

To make the process of passing parameter to inline forms more easier and consistent, I have additionally added the ```form_kwargs``` and the ```get_form_kwargs``` for passing  parameters  into each inline forms  at runtime or not. 

With these changes,  to change the arguments which are passed into each form within the formset, two options are now available:

 - The first approach is done either by the ```form_kwargs``` argument passed in to the FormSet constructor as previously mentionned in the documentation (I have solved the bug issue);
- The second approach (newly added) is done by simply declaring the ```form_kwargs``` option in the inline formset class or override the ```get_form_kwargs``` for passing  parameters  of inline forms  at runtime.

Here are some examples of using these news features. Note that, I use a fake Attribute class for the demonstration in theses examples, where the current user is passed into each inline forms:

```Python
class AttributeInline(InlineFormSetFactory):
    model = models.Attribute
    form_class = AttributeForm
    form_kwargs = {"user": 1}
```
Or override the  ```get_form_kwargs``` for passing  parameters  of inline forms  at runtime:

```Python
class AttributeInline(InlineFormSetFactory):
    model = models.Attribute
    form_class = AttributeForm

    def get_form_kwargs(self):
        form_kwargs = super(AttributeInline, self).get_form_kwargs()
        form_kwargs["user"] = self.request.user
        return form_kwargs
```

It is important to note that it can still be done using the ```get_formset_kwargs``` interface [see docs](https://django-extra-views.readthedocs.io/en/latest/pages/formset-customization.html#passing-arguments-to-the-form-constructor). However, the  ```form_kwargs``` declaration and ```get_form_kwargs``` interface are just more easier and consistent.

Thanks,

D. W. Liedji