### PR TITLE
Add form_kwargs and get_form_kwargs for inline forms with passed tested for black isort and flake8 .

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -72,8 +72,13 @@ class BaseFormSetFactory(object):
         Returns the keyword arguments for instantiating the formset.
         """
         kwargs = self.formset_kwargs.copy()
-        kwargs.update({"initial": self.get_initial(
-        ), "prefix": self.get_prefix(), "form_kwargs": self.get_form_kwargs()})
+        kwargs.update(
+            {
+                "initial": self.get_initial(),
+                "prefix": self.get_prefix(),
+                "form_kwargs": self.get_form_kwargs(),
+            }
+        )
 
         if self.request.method in ("POST", "PUT"):
             kwargs.update(

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -25,6 +25,7 @@ class BaseFormSetFactory(object):
     prefix = None
     formset_kwargs = {}
     factory_kwargs = {}
+    form_kwargs = {}
 
     def construct_formset(self):
         """
@@ -57,6 +58,9 @@ class BaseFormSetFactory(object):
         """
         return self.form_class
 
+    def get_form_kwargs(self):
+        return self.form_kwargs
+
     def get_formset(self):
         """
         Returns the formset class from the formset factory
@@ -68,7 +72,8 @@ class BaseFormSetFactory(object):
         Returns the keyword arguments for instantiating the formset.
         """
         kwargs = self.formset_kwargs.copy()
-        kwargs.update({"initial": self.get_initial(), "prefix": self.get_prefix()})
+        kwargs.update({"initial": self.get_initial(
+        ), "prefix": self.get_prefix(), "form_kwargs": self.get_form_kwargs()})
 
         if self.request.method in ("POST", "PUT"):
             kwargs.update(

--- a/extra_views/formsets.py
+++ b/extra_views/formsets.py
@@ -59,7 +59,7 @@ class BaseFormSetFactory(object):
         return self.form_class
 
     def get_form_kwargs(self):
-        return self.form_kwargs
+        return self.form_kwargs.copy()
 
     def get_formset(self):
         """
@@ -72,11 +72,12 @@ class BaseFormSetFactory(object):
         Returns the keyword arguments for instantiating the formset.
         """
         kwargs = self.formset_kwargs.copy()
+        form_kwargs = kwargs.get("form_kwargs", None)
         kwargs.update(
             {
                 "initial": self.get_initial(),
                 "prefix": self.get_prefix(),
-                "form_kwargs": self.get_form_kwargs(),
+                "form_kwargs": form_kwargs or self.get_form_kwargs(),
             }
         )
 


### PR DESCRIPTION
This is the version tested for black, isort and flake for the previews pull request [Add form_kwargs and get_form_kwargs for inline forms for solving issue](https://github.com/AndrewIngram/django-extra-views/commit/2b4a03cf5e5eb04796b63d5b2dac843f7779c70c) https://github.com/AndrewIngram/django-extra-views/issues/256 . I have added tested for black, isort and flake8 as recommended by @sdolemelipone .

