### PR TITLE
Added support for Python 3.12, Django 5.0.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,13 @@
 name: Tests
 on: [push, pull_request]
 env:
-  LATEST_PYTHON_VERSION: "3.11"
+  LATEST_PYTHON_VERSION: "3.12"
 jobs:
   tests:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,10 @@ Python     Django
 3.8-3.9  2.2–4.2
 3.10     3.2-4.2
 3.11     4.1-4.2
+3.12     4.2-5.0
 ======== ==========
 
-- Added support for Django 4.0, 4.1, 4.2 and Python 3.10, 3.11.
+- Added support for Django 4.0, 4.1, 4.2, 5.0 and Python 3.10, 3.11, 3.12.
 - Removed support for Django 2.1
 
 0.14.0 (2021-06-08)

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist = py35-django{22}
           py37-django{22,30,31,32}
           py38-django{22,30,31,32,40,41,42}
           py39-django{22,30,31,32,40,41,42}
-          py310-django{32,40,41,42,master}
-          py311-django{41,42,master}
+          py310-django{32,40,41,42,50,master}
+          py311-django{41,42,50,master}
+          py312-django{42,50,master}
           black
           isort
           flake8
@@ -19,7 +20,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311, docs
+    3.11: py311
+    3.12: py312, docs
 
 [testenv]
 setenv =
@@ -40,6 +42,7 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     djangomaster: https://github.com/django/django/archive/main.tar.gz
     pytest-django
     pytest-cov


### PR DESCRIPTION
Bumped test suite. Is it time to remove testing for 3.0 and 3.1 now?
https://endoflife.date/django