### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,14 @@
 name: Tests
 on: [push, pull_request]
 env:
-  LATEST_PYTHON_VERSION: "3.12"
+  LATEST_PYTHON_VERSION: "3.13"
 jobs:
   tests:
     if: github.repository == 'AndrewIngram/django-extra-views'
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   tests:
     if: github.repository == 'AndrewIngram/django-extra-views'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,23 @@ Change History
 
 0.16.0 (TBC)
 -------------------------
+
+Changes:
+~~~~~~~~
+Supported Versions:
+
+======== ==========
+Python     Django
+======== ==========
+3.8-3.9  2.2–4.2
+3.10     3.2-5.1
+3.11     4.1-5.1
+3.12     4.2-5.1
+======== ==========
+
 - Added `form_kwargs` and `get_form_kwargs()` to all `BaseFormSetFactory` classes for
   ease of use.
+- Removed official support for Python 3.6 and 3.7.
 
 0.15.0 (2024-09-27)
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,15 @@ Supported Versions:
 Python     Django
 ======== ==========
 3.8-3.9  2.2–4.2
-3.10     3.2-5.1
-3.11     4.1-5.1
-3.12     4.2-5.1
+3.10     3.2-5.2
+3.11     4.1-5.2
+3.12     4.2-5.2
+3.13     5.1-5.2
 ======== ==========
 
 - Added `form_kwargs` and `get_form_kwargs()` to all `BaseFormSetFactory` classes for
   ease of use.
-- Removed official support for Python 3.6 and 3.7.
+- Removed official support for Python 3.6 and 3.7, added Python 3.13.
 
 0.15.0 (2024-09-27)
 -------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist = py38-django{22,30,31,32,40,41,42}
           py39-django{22,30,31,32,40,41,42}
-          py310-django{32,40,41,42,50,51,master}
-          py311-django{41,42,50,51,master}
-          py312-django{42,50,51,master}
+          py310-django{32,40,41,42,50,51,52}
+          py311-django{41,42,50,51,52}
+          py312-django{42,50,51,52,master}
+          py313-django{51,52,master}
           black
           isort
           flake8
@@ -15,7 +16,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
-    3.12: py312, docs
+    3.12: py312
+    3.13: py313, docs
 
 [testenv]
 setenv =
@@ -38,6 +40,7 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
     djangomaster: https://github.com/django/django/archive/main.tar.gz
     pytest-django
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist = py36-django{22,30,31,32}
-          py37-django{22,30,31,32}
-          py38-django{22,30,31,32,40,41,42}
+envlist = py38-django{22,30,31,32,40,41,42}
           py39-django{22,30,31,32,40,41,42}
           py310-django{32,40,41,42,50,51,master}
           py311-django{41,42,50,51,master}
@@ -13,8 +11,6 @@ envlist = py36-django{22,30,31,32}
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
As Ubuntu 20.04 is no longer supported. This will probably make some Python versions unavailable for testing.