### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/extra_views/dates.py
+++ b/extra_views/dates.py
@@ -183,7 +183,7 @@ class BaseCalendarMonthView(DateMixin, YearMixin, MonthMixin, BaseListView):
         cal = Calendar(self.get_first_of_week())
 
         month_calendar = []
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
 
         date_lists = defaultdict(list)
         multidate_objs = []


### PR DESCRIPTION
# PR Summary
This small PR resolves the `datetime` deprecation warnings which you can see in the [CI logs](https://github.com/AndrewIngram/django-extra-views/actions/runs/14597839661/job/40948207865#step:5:93):
```python
/home/runner/work/django-extra-views/django-extra-views/extra_views/dates.py:186: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
      now = datetime.datetime.utcnow()
```